### PR TITLE
Implement parallel processing & copy buttons

### DIFF
--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+interface CopyButtonProps {
+  text: string;
+  tooltip: string;
+}
+
+export const CopyButton: React.FC<CopyButtonProps> = ({ text, tooltip }) => {
+  const handleCopy = () => {
+    navigator.clipboard.writeText(text);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="p-1 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 transition-colors duration-150"
+      title={tooltip}
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+    </button>
+  );
+};

--- a/components/ProgressBar.tsx
+++ b/components/ProgressBar.tsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 interface ProgressBarProps {
   progress: number;
-  currentProcessingUrl?: string;
+  currentProcessingUrls?: string[];
 }
 
-export const ProgressBar: React.FC<ProgressBarProps> = ({ progress, currentProcessingUrl }) => {
+export const ProgressBar: React.FC<ProgressBarProps> = ({ progress, currentProcessingUrls }) => {
   return (
     <div className="w-full bg-bggray-200 dark:bg-bggray-700 rounded-full h-6 shadow-inner overflow-hidden">
       <div
@@ -15,12 +15,14 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({ progress, currentProce
       >
         {progress.toFixed(0)}%
       </div>
-      {currentProcessingUrl && progress < 100 && (
+      {currentProcessingUrls && currentProcessingUrls.length > 0 && progress < 100 && (
          <p className="text-xs text-bggray-600 dark:text-bggray-300 mt-1 text-center">
-           Processing: <span className="font-semibold truncate inline-block max-w-sm align-bottom">{currentProcessingUrl}</span>
+           Processing: <span className="font-semibold truncate inline-block max-w-sm align-bottom">
+             {currentProcessingUrls.length === 1 ? currentProcessingUrls[0] : `${currentProcessingUrls.length} URLs`}
+           </span>
          </p>
       )}
-       {progress === 100 && !currentProcessingUrl && (
+       {progress === 100 && (!currentProcessingUrls || currentProcessingUrls.length === 0) && (
          <p className="text-xs text-green-600 dark:text-green-400 mt-1 text-center font-semibold">
            All URLs processed!
          </p>

--- a/components/UrlRow.tsx
+++ b/components/UrlRow.tsx
@@ -6,6 +6,7 @@ import { Spinner } from './Spinner';
 import { FrameworkTag } from './FrameworkTag';
 import { CharCounter } from './CharCounter';
 import { DownloadButton } from './DownloadButton';
+import { CopyButton } from './CopyButton';
 
 interface UrlRowProps {
   urlData: ProcessedUrl;
@@ -42,15 +43,21 @@ const ProposalItem: React.FC<{ proposal: MetadataProposal, index: number }> = ({
   return (
     <div className="py-2 border-b border-bggray-200 dark:border-bggray-700 last:border-b-0">
       <div className="font-semibold text-sm text-bggray-800 dark:text-bggray-100">Proposal {index + 1}</div>
-      <div className="mt-1">
-        <p className="text-xs text-bggray-600 dark:text-bggray-300">Title:</p>
-        <p className="text-sm break-words">{proposal.title}</p>
-        <CharCounter count={proposal.title.length} limit={MAX_TITLE_LENGTH} />
+      <div className="mt-1 flex items-start space-x-2">
+        <div className="flex-1">
+          <p className="text-xs text-bggray-600 dark:text-bggray-300">Title:</p>
+          <p className="text-sm break-words">{proposal.title}</p>
+          <CharCounter count={proposal.title.length} limit={MAX_TITLE_LENGTH} />
+        </div>
+        <CopyButton text={proposal.title} tooltip="Copy Title" />
       </div>
-      <div className="mt-1">
-        <p className="text-xs text-bggray-600 dark:text-bggray-300">Meta Description:</p>
-        <p className="text-sm break-words">{proposal.metaDescription}</p>
-        <CharCounter count={proposal.metaDescription.length} limit={MAX_META_DESC_LENGTH} />
+      <div className="mt-1 flex items-start space-x-2">
+        <div className="flex-1">
+          <p className="text-xs text-bggray-600 dark:text-bggray-300">Meta Description:</p>
+          <p className="text-sm break-words">{proposal.metaDescription}</p>
+          <CharCounter count={proposal.metaDescription.length} limit={MAX_META_DESC_LENGTH} />
+        </div>
+        <CopyButton text={proposal.metaDescription} tooltip="Copy Description" />
       </div>
     </div>
   );

--- a/constants.ts
+++ b/constants.ts
@@ -4,6 +4,9 @@ import { MarketingFramework, FrameworkData } from './types';
 export const MAX_TITLE_LENGTH = 65;
 export const MAX_META_DESC_LENGTH = 155;
 
+// Maximum number of URLs processed in parallel
+export const CONCURRENCY_LIMIT = 3;
+
 export const FRAMEWORK_DETAILS: Record<MarketingFramework | string, FrameworkData> = {
   [MarketingFramework.AIDA]: { name: "AIDA", color: "bg-red-500", description: "Attention, Interest, Desire, Action." },
   [MarketingFramework.PAS]: { name: "PAS", color: "bg-blue-600", description: "Problem, Agitate, Solution." },


### PR DESCRIPTION
## Summary
- limit concurrent URL processing with `CONCURRENCY_LIMIT`
- show active URLs in progress bar
- add copy buttons for SEO suggestions

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845d2cc6d708329b60b2e6c81724d51