### PR TITLE
Implement truncateAtWord utility and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "npx tsc utils/textHelpers.ts --lib ES2020,DOM --module ES2020 --target ES2020 --outDir dist && node --test tests/truncateAtWord.test.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -2,6 +2,7 @@
 import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
 import { MarketingFramework, MetadataProposal, DetectedFrameworkInfo } from '../types';
 import { MAX_TITLE_LENGTH, MAX_META_DESC_LENGTH, ALL_MARKETING_FRAMEWORKS_FOR_DETECTION } from '../constants';
+import { truncateAtWord } from '../utils/textHelpers';
 
 const API_KEY = process.env.API_KEY;
 if (!API_KEY || API_KEY === "YOUR_GEMINI_API_KEY") {
@@ -156,8 +157,8 @@ Do not include any other text or explanations outside the JSON array.
 
         // Validate and truncate if necessary (though the prompt is strict)
         return parsedJson.slice(0,3).map((p: any) => ({
-            title: String(p.title || "").substring(0, MAX_TITLE_LENGTH),
-            metaDescription: String(p.metaDescription || "").substring(0, MAX_META_DESC_LENGTH),
+            title: truncateAtWord(String(p.title || ""), MAX_TITLE_LENGTH),
+            metaDescription: truncateAtWord(String(p.metaDescription || ""), MAX_META_DESC_LENGTH),
         }));
     } catch (error) {
         console.error("Error generating metadata:", error);

--- a/tests/truncateAtWord.test.js
+++ b/tests/truncateAtWord.test.js
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { truncateAtWord } from '../dist/utils/textHelpers.js';
+
+test('returns text unchanged when under limit', () => {
+  const text = 'Short text';
+  assert.equal(truncateAtWord(text, 20), text);
+});
+
+test('truncates at last space before limit', () => {
+  const text = 'Hello world from Codex';
+  const result = truncateAtWord(text, 13); // substring would be 'Hello world f'
+  assert.equal(result, 'Hello world');
+  assert.ok(result.length <= 13);
+});
+
+test('falls back to hard cut when no space', () => {
+  const text = 'abcdefghijk';
+  const result = truncateAtWord(text, 5);
+  assert.equal(result, 'abcde');
+  assert.ok(result.length <= 5);
+});

--- a/utils/textHelpers.ts
+++ b/utils/textHelpers.ts
@@ -1,0 +1,9 @@
+export const truncateAtWord = (text: string, limit: number): string => {
+  if (text.length <= limit) return text;
+  const slice = text.substring(0, limit);
+  const lastSpace = slice.lastIndexOf(' ');
+  if (lastSpace === -1) {
+    return slice;
+  }
+  return slice.substring(0, lastSpace).trimEnd();
+};


### PR DESCRIPTION
## Summary
- add `truncateAtWord` helper for safer string trimming
- use `truncateAtWord` in `geminiService` when preparing metadata proposals
- add a simple Node test ensuring text is trimmed on word boundaries
- expose test run with npm script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845de4f50c483299a8d8fd141bcc94c