### PR TITLE
Improve truncation of metadata strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "npx tsc utils/textHelpers.ts --lib ES2020,DOM --module ES2020 --target ES2020 --outDir dist && node --test tests/truncateAtWord.test.js"
+    "test": "npx tsc utils/textHelpers.ts --lib ES2020,DOM --module ES2020 --target ES2020 --outDir dist && node --test tests/*.test.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -2,7 +2,7 @@
 import { GoogleGenAI, GenerateContentResponse } from "@google/genai";
 import { MarketingFramework, MetadataProposal, DetectedFrameworkInfo } from '../types';
 import { MAX_TITLE_LENGTH, MAX_META_DESC_LENGTH, ALL_MARKETING_FRAMEWORKS_FOR_DETECTION } from '../constants';
-import { truncateAtWord } from '../utils/textHelpers';
+import { truncateAtWord, truncateAtSentence } from '../utils/textHelpers';
 
 const API_KEY = process.env.API_KEY;
 if (!API_KEY || API_KEY === "YOUR_GEMINI_API_KEY") {
@@ -158,7 +158,7 @@ Do not include any other text or explanations outside the JSON array.
         // Validate and truncate if necessary (though the prompt is strict)
         return parsedJson.slice(0,3).map((p: any) => ({
             title: truncateAtWord(String(p.title || ""), MAX_TITLE_LENGTH),
-            metaDescription: truncateAtWord(String(p.metaDescription || ""), MAX_META_DESC_LENGTH),
+            metaDescription: truncateAtSentence(String(p.metaDescription || ""), MAX_META_DESC_LENGTH),
         }));
     } catch (error) {
         console.error("Error generating metadata:", error);

--- a/tests/truncateAtSentence.test.js
+++ b/tests/truncateAtSentence.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { truncateAtSentence } from '../dist/textHelpers.js';
+
+test('cuts at last punctuation mark when available', () => {
+  const text = 'Bonjour. Ceci est une phrase complete. Voici une autre phrase';
+  const result = truncateAtSentence(text, 50);
+  assert.equal(result, 'Bonjour. Ceci est une phrase complete.');
+  assert.ok(result.length <= 50);
+});
+
+test('falls back to word cut when no punctuation', () => {
+  const text = 'Aucune ponctuation ici vraiment';
+  const result = truncateAtSentence(text, 20);
+  assert.equal(result, 'Aucune ponctuation');
+  assert.ok(result.length <= 20);
+});

--- a/tests/truncateAtWord.test.js
+++ b/tests/truncateAtWord.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { truncateAtWord } from '../dist/utils/textHelpers.js';
+import { truncateAtWord } from '../dist/textHelpers.js';
 
 test('returns text unchanged when under limit', () => {
   const text = 'Short text';

--- a/utils/textHelpers.ts
+++ b/utils/textHelpers.ts
@@ -7,3 +7,13 @@ export const truncateAtWord = (text: string, limit: number): string => {
   }
   return slice.substring(0, lastSpace).trimEnd();
 };
+
+export const truncateAtSentence = (text: string, limit: number): string => {
+  if (text.length <= limit) return text;
+  const slice = text.substring(0, limit);
+  const lastPeriod = Math.max(slice.lastIndexOf('.'), slice.lastIndexOf('!'), slice.lastIndexOf('?'));
+  if (lastPeriod !== -1 && lastPeriod >= 0) {
+    return slice.substring(0, lastPeriod + 1).trim();
+  }
+  return truncateAtWord(text, limit);
+};


### PR DESCRIPTION
## Summary
- avoid ending metadata in the middle of a sentence with `truncateAtSentence`
- use new helper when trimming Gemini output
- update tests for new helper and compile path
- run both unit tests in `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845dc9170588329a136df2453ca5495