### PR TITLE
Improve truncateAtSentence logic

### DIFF
--- a/tests/truncateAtSentence.test.js
+++ b/tests/truncateAtSentence.test.js
@@ -15,3 +15,10 @@ test('falls back to word cut when no punctuation', () => {
   assert.equal(result, 'Aucune ponctuation');
   assert.ok(result.length <= 20);
 });
+
+test('ignores early period far from limit', () => {
+  const text = 'Hi. Here is some sample text that goes on without any other punctuation in sight';
+  const result = truncateAtSentence(text, 60);
+  assert.equal(result, 'Hi. Here is some sample text that goes on without any other');
+  assert.ok(result.length <= 60);
+});

--- a/utils/textHelpers.ts
+++ b/utils/textHelpers.ts
@@ -11,8 +11,12 @@ export const truncateAtWord = (text: string, limit: number): string => {
 export const truncateAtSentence = (text: string, limit: number): string => {
   if (text.length <= limit) return text;
   const slice = text.substring(0, limit);
-  const lastPeriod = Math.max(slice.lastIndexOf('.'), slice.lastIndexOf('!'), slice.lastIndexOf('?'));
-  if (lastPeriod !== -1 && lastPeriod >= 0) {
+  const lastPeriod = Math.max(
+    slice.lastIndexOf('.'),
+    slice.lastIndexOf('!'),
+    slice.lastIndexOf('?')
+  );
+  if (lastPeriod !== -1 && lastPeriod >= limit - 30) {
     return slice.substring(0, lastPeriod + 1).trim();
   }
   return truncateAtWord(text, limit);


### PR DESCRIPTION
## Summary
- adjust sentence truncation logic to only use punctuation near the limit
- test early punctuation to ensure fallback to word cutoff

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845e77026248329a0adfc97fb8c43da