### PR TITLE
Switch to GEMINI_API_KEY env var

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -3,15 +3,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
-// This is a placeholder for process.env.API_KEY.
+// This is a placeholder for process.env.GEMINI_API_KEY.
 // In a real build environment, this would be set through environment variables.
 // For demonstration purposes, you can replace "YOUR_GEMINI_API_KEY" with an actual key.
 // IMPORTANT: Do not commit your actual API key to version control.
-if (!process.env.API_KEY) {
-  process.env.API_KEY = "YOUR_GEMINI_API_KEY"; 
+if (!process.env.GEMINI_API_KEY) {
+  process.env.GEMINI_API_KEY = "YOUR_GEMINI_API_KEY";
 }
-if (process.env.API_KEY === "YOUR_GEMINI_API_KEY") {
-  console.warn("Using placeholder API Key for Gemini. Please set your actual API_KEY environment variable.");
+if (process.env.GEMINI_API_KEY === "YOUR_GEMINI_API_KEY") {
+  console.warn("Using placeholder Gemini API Key. Please set your actual GEMINI_API_KEY environment variable.");
 }
 
 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -4,12 +4,12 @@ import { MarketingFramework, MetadataProposal, DetectedFrameworkInfo } from '../
 import { MAX_TITLE_LENGTH, MAX_META_DESC_LENGTH, ALL_MARKETING_FRAMEWORKS_FOR_DETECTION } from '../constants';
 import { truncateAtWord, truncateAtSentence } from '../utils/textHelpers';
 
-const API_KEY = process.env.API_KEY;
-if (!API_KEY || API_KEY === "YOUR_GEMINI_API_KEY") {
-  console.error("Gemini API Key is not configured. Please set the API_KEY environment variable.");
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+if (!GEMINI_API_KEY || GEMINI_API_KEY === "YOUR_GEMINI_API_KEY") {
+  console.error("Gemini API Key is not configured. Please set the GEMINI_API_KEY environment variable.");
   // Potentially throw an error or handle this state in the UI
 }
-const ai = new GoogleGenAI({ apiKey: API_KEY! });
+const ai = new GoogleGenAI({ apiKey: GEMINI_API_KEY! });
 const modelName = 'gemini-2.5-flash-preview-04-17';
 
 function parseJsonFromGeminiResponse(text: string): any {
@@ -29,7 +29,7 @@ function parseJsonFromGeminiResponse(text: string): any {
 }
 
 export const detectFramework = async (textContent: string): Promise<DetectedFrameworkInfo> => {
-  if (!API_KEY || API_KEY === "YOUR_GEMINI_API_KEY") throw new Error("API Key not configured for Gemini.");
+  if (!GEMINI_API_KEY || GEMINI_API_KEY === "YOUR_GEMINI_API_KEY") throw new Error("Gemini API Key not configured.");
   const frameworksList = ALL_MARKETING_FRAMEWORKS_FOR_DETECTION.map(f => `- ${f.name}: ${f.description}`).join('\n');
 
   const prompt = `
@@ -100,11 +100,11 @@ Return your answer ONLY in JSON format like this:
 
 
 export const generateMetadata = async (
-    textContent: string, 
-    framework: MarketingFramework | string, 
+    textContent: string,
+    framework: MarketingFramework | string,
     justification: string
 ): Promise<MetadataProposal[]> => {
-    if (!API_KEY || API_KEY === "YOUR_GEMINI_API_KEY") throw new Error("API Key not configured for Gemini.");
+    if (!GEMINI_API_KEY || GEMINI_API_KEY === "YOUR_GEMINI_API_KEY") throw new Error("Gemini API Key not configured.");
 
     const frameworkDescription = ALL_MARKETING_FRAMEWORKS_FOR_DETECTION.find(f => f.name === framework)?.description || justification;
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- use `process.env.GEMINI_API_KEY` in the Gemini service
- update placeholder API key logic in the entrypoint
- simplify Vite config mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845f0c1b7348329b0215488b3d96015