### PR TITLE
Fix sentence truncation with early periods

### DIFF
--- a/tests/truncateAtSentence.test.js
+++ b/tests/truncateAtSentence.test.js
@@ -22,3 +22,11 @@ test('ignores early period far from limit', () => {
   assert.equal(result, 'Hi. Here is some sample text that goes on without any other');
   assert.ok(result.length <= 60);
 });
+
+test('period near start leads to word truncation near limit', () => {
+  const text =
+    'Short. This is a longer piece with no punctuation near the limit whatsoever';
+  const result = truncateAtSentence(text, 40);
+  assert.equal(result, 'Short. This is a longer piece with no');
+  assert.ok(result.length <= 40);
+});

--- a/utils/textHelpers.ts
+++ b/utils/textHelpers.ts
@@ -18,7 +18,8 @@ export const truncateAtSentence = (text: string, limit: number): string => {
     slice.lastIndexOf('!'),
     slice.lastIndexOf('?')
   );
-  if (lastPeriod !== -1 && lastPeriod >= limit - SENTENCE_WINDOW) {
+  const isNearLimit = lastPeriod !== -1 && limit - lastPeriod <= SENTENCE_WINDOW;
+  if (isNearLimit) {
     return slice.substring(0, lastPeriod + 1).trim();
   }
   return truncateAtWord(text, limit);


### PR DESCRIPTION
## Summary
- only cut at punctuation if within the 30 char `SENTENCE_WINDOW`
- add test for early punctuation near start

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6845f71f21608329a86e987e054da057