### PR TITLE
Add localStorage persistence for language

### DIFF
--- a/i18n.tsx
+++ b/i18n.tsx
@@ -7,7 +7,11 @@ type Language = 'en' | 'fr';
 const resources = { en, fr } as const;
 
 const detectBrowserLanguage = (): Language => {
-  if (typeof navigator !== 'undefined') {
+  if (typeof window !== 'undefined') {
+    const stored = localStorage.getItem('lang');
+    if (stored === 'en' || stored === 'fr') {
+      return stored;
+    }
     const lang = navigator.language.split('-')[0];
     if (lang === 'fr') return 'fr';
   }
@@ -28,6 +32,23 @@ const I18nContext = createContext<I18nContextProps>({
 
 export const I18nProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [lang, setLang] = useState<Language>(detectBrowserLanguage());
+
+  // Load stored language preference on mount
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const stored = localStorage.getItem('lang');
+      if (stored === 'en' || stored === 'fr') {
+        setLang(stored);
+      }
+    }
+  }, []);
+
+  // Persist language preference whenever it changes
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('lang', lang);
+    }
+  }, [lang]);
 
   const t = (key: keyof typeof en, vars?: Record<string, string | number>) => {
     const str = (resources[lang] as any)[key] ?? (resources.en as any)[key] ?? key;


### PR DESCRIPTION
## Summary
- persist selected language in localStorage
- read stored language on mount
- rename `i18n.ts` to `i18n.tsx`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa5d9228083298a969ac82366b20b