### PR TITLE
Update README with language info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This contains everything you need to run your app locally.
 
+The interface is displayed in **French** by default. When processing pages, the tool automatically detects the language of each page and generates the SEO title and meta description in that same language.
+
 ## Run Locally
 
 **Prerequisites:**  Node.js
@@ -9,6 +11,6 @@ This contains everything you need to run your app locally.
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
+2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key (also used if `detectLanguage` relies on Gemini)
 3. Run the app:
    `npm run dev`


### PR DESCRIPTION
## Summary
- mention that the UI defaults to French
- note automatic language detection for metadata
- clarify that `GEMINI_API_KEY` is used for both metadata generation and language detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa9eb0a388329854fb0bf5d711328