### PR TITLE
Add language detection utility tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "npx tsc utils/textHelpers.ts --lib ES2020,DOM --module ES2020 --target ES2020 --outDir dist && node --test tests/*.test.js"
+    "test": "npx tsc utils/textHelpers.ts utils/detectLanguage.ts --lib ES2020,DOM --module ES2020 --target ES2020 --outDir dist && node --test tests/*.test.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/tests/detectLanguage.test.js
+++ b/tests/detectLanguage.test.js
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { detectLanguage } from '../dist/detectLanguage.js';
+
+const mockAI = (lang) => ({
+  models: {
+    generateContent: async () => ({ text: lang })
+  }
+});
+
+test('detects English text', async () => {
+  const lang = await detectLanguage('Hello world', mockAI('en'));
+  assert.equal(lang, 'en');
+});
+
+test('detects French text', async () => {
+  const lang = await detectLanguage('Bonjour le monde', mockAI('fr'));
+  assert.equal(lang, 'fr');
+});

--- a/utils/detectLanguage.ts
+++ b/utils/detectLanguage.ts
@@ -1,0 +1,14 @@
+export interface GeminiLike {
+  models: {
+    generateContent: (opts: any) => Promise<{ text: string }>
+  };
+}
+
+export const detectLanguage = async (
+  text: string,
+  genAI: GeminiLike
+): Promise<string> => {
+  const prompt = `Identify the primary language of the text below. Reply only with the ISO 639-1 code.\n\n${text}`;
+  const response = await genAI.models.generateContent({ contents: prompt });
+  return response.text.trim();
+};


### PR DESCRIPTION
## Summary
- create a simple `detectLanguage` utility
- compile new utility during tests
- add unit tests for detecting English and French

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684aa9ed6a4c8329be69dcf0fb27915e