### PR TITLE
Switch environment variables to OpenAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ The interface is displayed in **French** by default. When processing pages, the 
 
 1. Install dependencies:
    `npm install`
-2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key (also used if `detectLanguage` relies on Gemini)
+2. Add your `OPENAI_API_KEY` to an `.env.local` file. You can also set `OPENAI_MODEL` to override the default model (`gpt-3.5-turbo`).
 3. Run the app:
    `npm run dev`
+
+The app defaults to OpenAI's `gpt-3.5-turbo` model. Free or new accounts may have strict rate limits, so adjust usage or upgrade your plan accordingly.

--- a/index.tsx
+++ b/index.tsx
@@ -4,15 +4,15 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import { I18nProvider } from './i18n.tsx';
 
-// This is a placeholder for process.env.GEMINI_API_KEY.
+// This is a placeholder for process.env.OPENAI_API_KEY.
 // In a real build environment, this would be set through environment variables.
-// For demonstration purposes, you can replace "YOUR_GEMINI_API_KEY" with an actual key.
+// For demonstration purposes, you can replace "YOUR_OPENAI_API_KEY" with an actual key.
 // IMPORTANT: Do not commit your actual API key to version control.
-if (!process.env.GEMINI_API_KEY) {
-  process.env.GEMINI_API_KEY = "YOUR_GEMINI_API_KEY";
+if (!process.env.OPENAI_API_KEY) {
+  process.env.OPENAI_API_KEY = "YOUR_OPENAI_API_KEY";
 }
-if (process.env.GEMINI_API_KEY === "YOUR_GEMINI_API_KEY") {
-  console.warn("Using placeholder Gemini API Key. Please set your actual GEMINI_API_KEY environment variable.");
+if (process.env.OPENAI_API_KEY === "YOUR_OPENAI_API_KEY") {
+  console.warn("Using placeholder OpenAI API Key. Please set your actual OPENAI_API_KEY environment variable.");
 }
 
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,8 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
+        'process.env.OPENAI_API_KEY': JSON.stringify(env.OPENAI_API_KEY),
+        'process.env.OPENAI_MODEL': JSON.stringify(env.OPENAI_MODEL)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- configure Vite to expose `OPENAI_API_KEY` and `OPENAI_MODEL`
- check for `OPENAI_API_KEY` in `index.tsx`
- document `OPENAI_API_KEY` usage and default model

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684abb75f72083298458430e877580e0