### PR TITLE
Rename interface for generic LLM

### DIFF
--- a/utils/detectLanguage.ts
+++ b/utils/detectLanguage.ts
@@ -1,4 +1,4 @@
-export interface GeminiLike {
+export interface LLMLike {
   models: {
     generateContent: (opts: any) => Promise<{ text: string }>
   };
@@ -6,7 +6,7 @@ export interface GeminiLike {
 
 export const detectLanguage = async (
   text: string,
-  genAI: GeminiLike
+  genAI: LLMLike
 ): Promise<string> => {
   const prompt = `Identify the primary language of the text below. Reply only with the ISO 639-1 code.\n\n${text}`;
   const response = await genAI.models.generateContent({ contents: prompt });


### PR DESCRIPTION
## Summary
- rename `GeminiLike` interface to `LLMLike`
- use the new interface in `detectLanguage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684abb80e604832989ac6952342beeb9