### PR TITLE
Ensure OpenAI provider usage

### DIFF
--- a/services/openaiService.ts
+++ b/services/openaiService.ts
@@ -8,7 +8,12 @@ if (!OPENAI_API_KEY || OPENAI_API_KEY === "YOUR_OPENAI_API_KEY") {
   console.error('OpenAI API Key is not configured. Please set the OPENAI_API_KEY environment variable.');
 }
 
-const ai = new OpenAI({ apiKey: OPENAI_API_KEY! });
+let ai = new OpenAI({ apiKey: OPENAI_API_KEY! });
+
+// Allows injecting a custom OpenAI client (e.g. for tests)
+export const setOpenAIClient = (client: OpenAI) => {
+  ai = client;
+};
 const modelName = 'gpt-4o';
 
 function parseJsonFromOpenAIResponse(text: string): any {


### PR DESCRIPTION
## Summary
- allow `openaiService` to accept a custom OpenAI client
- ensure environment variable OPENAI_API_KEY consistently documented

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae75fe96c83298068bd83fca2d43e