### PR TITLE
Add CSV parser tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "npx tsc utils/textHelpers.ts utils/detectLanguage.ts --lib ES2020,DOM --module ES2020 --target ES2020 --outDir dist && node --test tests/*.test.js"
+    "test": "npx tsc utils/textHelpers.ts utils/detectLanguage.ts utils/csvParser.ts --lib ES2020,DOM --module ES2020 --target ES2020 --outDir dist && node --test tests/*.test.js"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/tests/csvParser.test.js
+++ b/tests/csvParser.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCSV } from '../dist/csvParser.js';
+
+class MockFileReader {
+  constructor() {
+    this.onload = null;
+    this.onerror = null;
+  }
+  readAsText(file) {
+    file.text().then(text => {
+      if (this.onload) this.onload({ target: { result: text } });
+    }).catch(err => {
+      if (this.onerror) this.onerror(err);
+    });
+  }
+}
+
+class FailingFileReader {
+  constructor() {
+    this.onload = null;
+    this.onerror = null;
+  }
+  readAsText() {
+    if (this.onerror) this.onerror(new Error('fail'));
+  }
+}
+
+test('parses newline separated URLs', async () => {
+  global.FileReader = MockFileReader;
+  const file = new File(['https://example.com\nhttps://openai.com'], 'urls.csv');
+  const urls = await parseCSV(file);
+  assert.deepEqual(urls, ['https://example.com', 'https://openai.com']);
+});
+
+test('parses comma separated URLs using first column', async () => {
+  global.FileReader = MockFileReader;
+  const file = new File([
+    'https://a.com,first\nhttps://b.com,second'
+  ], 'urls.csv');
+  const urls = await parseCSV(file);
+  assert.deepEqual(urls, ['https://a.com', 'https://b.com']);
+});
+
+test('rejects when file is empty', async () => {
+  global.FileReader = MockFileReader;
+  const file = new File([''], 'empty.csv');
+  await assert.rejects(() => parseCSV(file), {
+    message: 'File is empty or could not be read.'
+  });
+});
+
+test('rejects when no valid URLs found', async () => {
+  global.FileReader = MockFileReader;
+  const file = new File(['not,a,url'], 'bad.csv');
+  await assert.rejects(() => parseCSV(file), {
+    message: 'No valid URLs found in the CSV file. Ensure URLs start with http:// or https:// and are in the first column or one per line.'
+  });
+});
+
+test('rejects on read error', async () => {
+  global.FileReader = FailingFileReader;
+  const file = new File(['https://example.com'], 'urls.csv');
+  await assert.rejects(() => parseCSV(file), { message: 'Failed to read file.' });
+});


### PR DESCRIPTION
## Summary
- test utils/csvParser parsing and error handling
- compile csvParser.ts during npm test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684dd231456083298a67db6934512e23