### PR TITLE
Expose concurrency settings and model choice

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The interface is displayed in **French** by default. When processing pages, the 
 1. Install dependencies:
    `npm install`
 2. Set the `OPENAI_API_KEY` in [.env.local](.env.local) to your OpenAI API key
-3. Run the app:
+3. (Optional) Set `CONCURRENCY_LIMIT` to control how many URLs are processed in parallel and `OPENAI_MODEL` to specify the OpenAI model.
+4. Run the app:
    `npm run dev`
 
 ## License

--- a/constants.ts
+++ b/constants.ts
@@ -4,8 +4,8 @@ import { MarketingFramework, FrameworkData } from './types';
 export const MAX_TITLE_LENGTH = 65;
 export const MAX_META_DESC_LENGTH = 155;
 
-// Maximum number of URLs processed in parallel
-export const CONCURRENCY_LIMIT = 3;
+// Maximum number of URLs processed in parallel. Can be overridden via env var CONCURRENCY_LIMIT
+export const CONCURRENCY_LIMIT = parseInt(process.env.CONCURRENCY_LIMIT || '3', 10);
 
 export const FRAMEWORK_DETAILS: Record<MarketingFramework | string, FrameworkData> = {
   [MarketingFramework.AIDA]: { name: "AIDA", color: "bg-red-500", description: "Attention, Interest, Desire, Action." },

--- a/services/openaiService.ts
+++ b/services/openaiService.ts
@@ -26,7 +26,7 @@ const getAIClient = (): OpenAI => {
 export const setOpenAIClient = (client: OpenAI) => {
   ai = client;
 };
-const modelName = 'gpt-4o';
+const modelName = process.env.OPENAI_MODEL || 'gpt-4o';
 
 function parseJsonFromOpenAIResponse(text: string): any {
   try {
@@ -73,12 +73,11 @@ Extrait du contenu de la page (1500 premiers caract\u00e8res) :
 ${textContent.substring(0, 1500)}
 ---
 
-Cadres marketing possibles :
+Cadres marketing disponibles :
 ${frameworksList}
-- NONE : pour un contenu g\u00e9n\u00e9ral ou lorsqu'aucun cadre sp\u00e9cifique ne s'applique.
 
-Quel cadre marketing est le plus pr\u00e9sent ou serait le plus efficace pour ce contenu ?
-Donne uniquement le nom du cadre (ex. AIDA, PAS, STDC, BAB, FAB, QUEST, NONE) ainsi qu'une phrase concise (20 mots maximum) justifiant ton choix.
+Quel cadre marketing recommanderais-tu pour ce contenu ? Choisis celui qui serait le plus efficace, même si aucun n'est clairement identifiable.
+Donne uniquement le nom du cadre (ex. AIDA, PAS, STDC, BAB, FAB, QUEST) ainsi qu'une phrase concise (20 mots maximum) justifiant ton choix.
 
 R\u00e9ponds UNIQUEMENT en JSON au format :
 {"framework": "NOM_DU_CADRE", "justification": "Ta justification concise ici."}`;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,9 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.OPENAI_API_KEY': JSON.stringify(env.OPENAI_API_KEY)
+        'process.env.OPENAI_API_KEY': JSON.stringify(env.OPENAI_API_KEY),
+        'process.env.CONCURRENCY_LIMIT': JSON.stringify(env.CONCURRENCY_LIMIT),
+        'process.env.OPENAI_MODEL': JSON.stringify(env.OPENAI_MODEL)
       },
       resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- pick openai model from `OPENAI_MODEL` env var
- let `CONCURRENCY_LIMIT` be configured via env var
- adjust framework detection prompt to always recommend a framework
- document new environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e3794d7a48329aa2af7e576bee7c8